### PR TITLE
Update microsoft.go GroupNameFormat type as it doesnt seem to be working as expected

### DIFF
--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -27,8 +27,8 @@ type GroupNameFormat string
 
 // Possible values for GroupNameFormat
 const (
-	GroupID   GroupNameFormat = "id"
-	GroupName GroupNameFormat = "name"
+	GroupID   string = "id"
+	GroupName string = "name"
 )
 
 const (
@@ -50,7 +50,7 @@ type Config struct {
 	Tenant               string          `json:"tenant"`
 	OnlySecurityGroups   bool            `json:"onlySecurityGroups"`
 	Groups               []string        `json:"groups"`
-	GroupNameFormat      GroupNameFormat `json:"groupNameFormat"`
+	GroupNameFormat      string          `json:"groupNameFormat"`
 	UseGroupsAsWhitelist bool            `json:"useGroupsAsWhitelist"`
 	EmailToLowercase     bool            `json:"emailToLowercase"`
 
@@ -118,7 +118,7 @@ type microsoftConnector struct {
 	clientSecret         string
 	tenant               string
 	onlySecurityGroups   bool
-	groupNameFormat      GroupNameFormat
+	groupNameFormat      string
 	groups               []string
 	useGroupsAsWhitelist bool
 	logger               log.Logger


### PR DESCRIPTION
This is related to this commit https://github.com/favipcj/dex/commit/68a936d2a9e8f07ddbf111a238b805a7ab487700 (dex 22 version)

We thought that would be solved in the latest version dex(37) currently. But that is still failing

Error
```
panic: interface conversion: interface {} is microsoft.GroupNameFormat, not string
goroutine 1 [running]:
...
```
